### PR TITLE
CGI::Fast (and FCGI) became mandatory as of 6.2.23b.1

### DIFF
--- a/SPECS/sympa-6.2.spec.in
+++ b/SPECS/sympa-6.2.spec.in
@@ -54,11 +54,13 @@ BuildRequires: perl-generators
 # install & check
 BuildRequires: perl(Archive::Zip)
 BuildRequires: perl(CGI::Cookie)
+BuildRequires: perl(CGI::Fast)
 BuildRequires: perl(CGI::Util)
 BuildRequires: perl(Data::Password)
 BuildRequires: perl(DateTime)
 BuildRequires: perl(DateTime::Format::Mail)
 BuildRequires: perl(DBI)
+BuildRequires: perl(FCGI)
 BuildRequires: perl(File::Copy::Recursive)
 BuildRequires: perl(File::NFSLock)
 BuildRequires: perl(HTML::Entities)


### PR DESCRIPTION
So `BuildRequires` lines should be added.