### PR TITLE
Small fixes for RPM postinstall shell errors

### DIFF
--- a/SPECS/sympa-6.2.spec.in
+++ b/SPECS/sympa-6.2.spec.in
@@ -491,7 +491,7 @@ function upgrade_data_structure {
 
 # Migrate /etc/sysconfig/sympa from previous RPM releases.
 function migrate_sysconfig_sympa {
-  [ -f %{_sysconfdir}/sysconfig/sympa ] || return
+  [ -f %{_sysconfdir}/sysconfig/sympa ] || return 0
   grep -q '^aliases_program' %{_sysconfdir}/sympa/sympa.conf && return
   . %{_sysconfdir}/sysconfig/sympa
 

--- a/SPECS/sympa-6.2.spec.in
+++ b/SPECS/sympa-6.2.spec.in
@@ -474,7 +474,7 @@ function upgrade_data_structure {
     rm -f %{_sysconfdir}/sympa/sympa.conf.bin > /dev/null 2>&1
     if %{_sbindir}/sympa.pl --upgrade > /dev/null 2>&1; then
         # Start sympa if it was running previously
-        if [ $ACTIVE == "yes" ]; then
+        if [ "$ACTIVE" == "yes" ]; then
 %if %{use_systemd}
             /usr/bin/systemctl start sympa > /dev/null 2>&1
 %else


### PR DESCRIPTION
Hello,

Thank you for keeping the RPM build process alive, even if not part of the main Sympa development effort. We rely on RPM-based installations at our site and were planning to maintain our Sympa installations in the future using RPM.

This PR is to address two small shell errors I encountered in the postinstall scripts while attempting to upgrade to Sympa 6.2.23b.2 built for RHEL 7.3 using this SPEC file template.

* Handle the case where $ACTIVE is not previously set in the script
* Return th an exit status of 0 if /etc/sysconfig/sympa does not exist, avoiding an RPM "nonzero exit status" error 