### PR TITLE
fixup rebase error in c1729188

### DIFF
--- a/SPECS/sympa-6.2.spec.in
+++ b/SPECS/sympa-6.2.spec.in
@@ -644,7 +644,6 @@ rm -rf %{_localstatedir}/lib/sympa/static_content/external/font-awesome/{css,fon
 %dir %attr(-,sympa,sympa) %{_sysconfdir}/sympa/families
 %dir %attr(-,sympa,sympa) %{_sysconfdir}/sympa/search_filters
 %config(missingok) %attr(-,sympa,sympa) %{_sysconfdir}/sympa/data_structure.current_version
-%config(noreplace) %attr(-,sympa,sympa) %{_sysconfdir}/sympa/aliases
 %config(noreplace) %{_sysconfdir}/sympa/aliases.sympa.sendmail
 %config(noreplace) %{_sysconfdir}/sympa/aliases.sympa.postfix
 %{_sysconfdir}/smrsh/*


### PR DESCRIPTION
Hi Soji,

This fixes the error you noticed in https://github.com/ikedas/sympa-rpm/pull/14#issuecomment-351673892 that I introduced in c1729188, adding an inexistant %{_sysconfdir}/sympa/aliases in %files.
Bad rebase, sorry... :-(

Regards,
Xavier