### PR TITLE
6.2.25 beta 2 plus static_content dir move

### DIFF
--- a/SOURCES/sympa-httpd22-fcgid.conf
+++ b/SOURCES/sympa-httpd22-fcgid.conf
@@ -1,4 +1,4 @@
-### Apache Configuration for Sympa
+### Apache httpd 2.2 configuration for Sympa
 
 ## Definition of Sympa FastCGI server.
 <IfModule mod_fcgid.c>
@@ -10,7 +10,6 @@
     # If you changed wwsympa_url in sympa.conf, change this path too.
     <Location /sympa>
         SetHandler fcgid-script
-
         # Don't forget to edit lines below!
         Order deny,allow
         Deny from all
@@ -21,7 +20,6 @@
 #    # You may uncomment following lines to enable SympaSOAP feature.
 #    <Location /sympasoap>
 #        SetHandler fcgid-script
-#
 #        # Don't forget to edit lines below!
 #        Order deny,allow
 #        Deny from all

--- a/SOURCES/sympa-httpd22-fcgid.conf
+++ b/SOURCES/sympa-httpd22-fcgid.conf
@@ -33,7 +33,9 @@
 ## Other static contents
 Alias /static-sympa/external/font-awesome/css /usr/share/font-awesome-web/css
 Alias /static-sympa/external/font-awesome/fonts /usr/share/fonts/fontawesome
-Alias /static-sympa /var/lib/sympa/static_content
+Alias /static-sympa/css /var/lib/sympa/css
+Alias /static-sympa/pictures /var/lib/sympa/pictures
+Alias /static-sympa /usr/share/sympa/static_content
 
 ## If your host is dedicated to Sympa:
 #RewriteEngine on

--- a/SOURCES/sympa-httpd24-fcgid.conf
+++ b/SOURCES/sympa-httpd24-fcgid.conf
@@ -1,4 +1,4 @@
-### Apache Configuration for Sympa
+### Apache httpd 2.4 configuration for Sympa
 
 ## Definition of Sympa FastCGI server.
 <IfModule mod_fcgid.c>
@@ -10,14 +10,18 @@
     # If you changed wwsympa_url in sympa.conf, change this path too.
     <Location /sympa>
         SetHandler fcgid-script
-        Require all granted
+        # Don't forget to edit lines below!
+        Require local
+        #Require all granted
     </Location>
     ScriptAlias /sympa /usr/libexec/sympa/wwsympa-wrapper.fcgi
 
 #    # You may uncomment following lines to enable SympaSOAP feature.
 #    <Location /sympasoap>
 #        SetHandler fcgid-script
-#        Require all granted
+#        # Don't forget to edit lines below!
+#        Require local
+#        #Require all granted
 #    </Location>
 #    ScriptAlias /sympasoap /usr/libexec/sympa/sympa_soap_server-wrapper.fcgi
 </IfModule>

--- a/SOURCES/sympa-httpd24-fcgid.conf
+++ b/SOURCES/sympa-httpd24-fcgid.conf
@@ -28,7 +28,9 @@
 </Location>
 Alias /static-sympa/external/font-awesome/css /usr/share/font-awesome-web/css
 Alias /static-sympa/external/font-awesome/fonts /usr/share/fonts/fontawesome
-Alias /static-sympa /var/lib/sympa/static_content
+Alias /static-sympa/css /var/lib/sympa/css
+Alias /static-sympa/pictures /var/lib/sympa/pictures
+Alias /static-sympa /usr/share/sympa/static_content
 
 ## If your host is dedicated to Sympa:
 #RewriteEngine on

--- a/SOURCES/sympa-lighttpd.conf
+++ b/SOURCES/sympa-lighttpd.conf
@@ -3,7 +3,9 @@ server.modules += ("mod_alias")
  
 alias.url += ( "/static-sympa/external/font-awesome/css/" => "/usr/share/font-awesome-web/css/" )
 alias.url += ( "/static-sympa/external/font-awesome/fonts/" => "/usr/share/fonts/fontawesome/" )
-alias.url += ( "/static-sympa/" => "/var/lib/sympa/static_content/" )
+alias.url += ( "/static-sympa/css/" => "/var/lib/sympa/css/" )
+alias.url += ( "/static-sympa/pictures/" => "/var/lib/sympa/pictures/" )
+alias.url += ( "/static-sympa/" => "/usr/share/sympa/static_content/" )
  
 $HTTP["url"] =~ "\^/sympa" {
 fastcgi.server = ( "/sympa" =>

--- a/SOURCES/sympa-lighttpd.conf
+++ b/SOURCES/sympa-lighttpd.conf
@@ -1,12 +1,12 @@
 server.modules += ("mod_fastcgi")
 server.modules += ("mod_alias")
- 
+
 alias.url += ( "/static-sympa/external/font-awesome/css/" => "/usr/share/font-awesome-web/css/" )
 alias.url += ( "/static-sympa/external/font-awesome/fonts/" => "/usr/share/fonts/fontawesome/" )
 alias.url += ( "/static-sympa/css/" => "/var/lib/sympa/css/" )
 alias.url += ( "/static-sympa/pictures/" => "/var/lib/sympa/pictures/" )
 alias.url += ( "/static-sympa/" => "/usr/share/sympa/static_content/" )
- 
+
 $HTTP["url"] =~ "\^/sympa" {
 fastcgi.server = ( "/sympa" =>
     ((    "check-local"    =>    "disable",

--- a/SOURCES/sympa-nginx-spawn_fcgi.conf
+++ b/SOURCES/sympa-nginx-spawn_fcgi.conf
@@ -18,8 +18,14 @@ server {
     location /static-sympa/external/font-awesome/fonts {
         alias /usr/share/fonts/fontawesome;
     }
+    location /static-sympa/css {
+        alias /var/lib/sympa/css;
+    }
+    location /static-sympa/pictures {
+        alias /var/lib/sympa/pictures;
+    }
     location /static-sympa {
-        alias /var/lib/sympa/static_content;
+        alias /usr/share/sympa/static_content;
     }
 }
 

--- a/SPECS/sympa-6.2.spec.in
+++ b/SPECS/sympa-6.2.spec.in
@@ -534,6 +534,24 @@ getent passwd sympa >/dev/null || \
       -c "System User for Sympa" \
       -s "/sbin/nologin" \
       sympa
+
+# Fix CSS and pictures paths
+if [ $1 -gt 1 ]; then
+    if [ -d %{_localstatedir}/lib/%{name}/static_content/css ]; then
+        mv -fu %{_localstatedir}/lib/%{name}/static_content/css/* \
+            %{_localstatedir}/lib/%{name}/css/ \
+            && rm -rf %{_localstatedir}/lib/%{name}/static_content/css/
+    fi
+    if [ -d %{_localstatedir}/lib/%{name}/static_content/pictures ]; then
+        mv -fu %{_localstatedir}/lib/%{name}/static_content/pictures/* \
+            %{_localstatedir}/lib/%{name}/pictures/ \
+            && rm -rf %{_localstatedir}/lib/%{name}/static_content/pictures/
+    fi
+    if [ ! -d %{_localstatedir}/lib/%{name}/static_content/css \
+        -a ! -d %{_localstatedir}/lib/%{name}/static_content/pictures ]; then
+        rm -r %{_localstatedir}/lib/%{name}/static_content/
+    fi
+fi
 exit 0
 
 

--- a/SPECS/sympa-6.2.spec.in
+++ b/SPECS/sympa-6.2.spec.in
@@ -4,6 +4,8 @@
 %global use_systemd 0
 %endif
 
+%global static_content %{_datadir}/sympa/static_content
+
 %global unbundle_raleway        0%{?fedora}
 
 %global unbundle_foundation     0
@@ -376,6 +378,9 @@ autoreconf --install
     --with-smrshdir=%{_sysconfdir}/smrsh \
     --with-aliases_file=%{_localstatedir}/lib/sympa/sympa_aliases \
     --with-perl=%{_bindir}/perl \
+    --with-staticdir=%{static_content} \
+    --with-cssdir=%{_localstatedir}/lib/sympa/css \
+    --with-picturesdir=%{_localstatedir}/lib/sympa/pictures \
     INSTALL_DATA='install -c -p -m 644'
 %make_build
 
@@ -396,12 +401,12 @@ pushd po/web_help; rm -f stamp-po; make; popd
 chmod a-x %{buildroot}%{_datadir}/%{name}/bin/create_db.Sybase
 
 # Unbundle fonts from static_content/external/font-awesome
-rm -rf %{buildroot}/%{_localstatedir}/lib/sympa/static_content/external/font-awesome
+rm -rf %{buildroot}/%{static_content}/external/font-awesome
 # Unbundle fonts from static_content/fonts/Raleway
 %if %{unbundle_raleway}
-rm -f %{buildroot}/%{_localstatedir}/lib/sympa/static_content/fonts/Raleway/Raleway-Regular.otf
+rm -f %{buildroot}/%{static_content}/fonts/Raleway/Raleway-Regular.otf
 ln -s %{_datadir}/fonts/impallari-raleway/Raleway-Regular.otf \
-    %{buildroot}/%{_localstatedir}/lib/sympa/static_content/fonts/Raleway/Raleway-Regular.otf
+    %{buildroot}/%{static_content}/fonts/Raleway/Raleway-Regular.otf
 %endif
 # FIXME: Unbundle static_content/fonts/foundation-icons
 
@@ -409,15 +414,15 @@ ln -s %{_datadir}/fonts/impallari-raleway/Raleway-Regular.otf \
 # FIXME : foundation
 # html5shiv
 %if %{unbundle_html5shiv}
-rm -rf %{buildroot}/%{_localstatedir}/lib/sympa/static_content/external/html5shiv/html5shiv.js
+rm -rf %{buildroot}/%{static_content}/external/html5shiv/html5shiv.js
 ln -s %{_datadir}/javascript/html5shiv.js \
-    %{buildroot}/%{_localstatedir}/lib/sympa/static_content/external/html5shiv/html5shiv.js
+    %{buildroot}/%{static_content}/external/html5shiv/html5shiv.js
 %endif
 # jquery
 %if %{unbundle_jquery}
-rm -rf %{buildroot}/%{_localstatedir}/lib/sympa/static_content/external/jquery.js
+rm -rf %{buildroot}/%{static_content}/external/jquery.js
 ln -s %{_datadir}/javascript/jquery/3/jquery.js \
-    %{buildroot}/%{_localstatedir}/lib/sympa/static_content/external/jquery.js
+    %{buildroot}/%{static_content}/external/jquery.js
 %endif
 # FIXME : jquery-migrate
 # FIXME : jquery-ui
@@ -425,9 +430,9 @@ ln -s %{_datadir}/javascript/jquery/3/jquery.js \
 # FIXME : modernizr
 # respond
 %if %{unbundle_respond}
-rm -rf %{buildroot}/%{_localstatedir}/lib/sympa/static_content/external/respondjs/respond.min.js
+rm -rf %{buildroot}/%{static_content}/external/respondjs/respond.min.js
 ln -s %{_datadir}/javascript/respond.min.js \
-    %{buildroot}/%{_localstatedir}/lib/sympa/static_content/external/respondjs/respond.min.js
+    %{buildroot}/%{static_content}/external/respondjs/respond.min.js
 %endif
 
 # Save version info.
@@ -730,14 +735,9 @@ fi
 %dir %{_localstatedir}/lib/sympa/
 %attr(-,sympa,sympa) %{_localstatedir}/lib/sympa/arc/
 %attr(-,sympa,sympa) %{_localstatedir}/lib/sympa/bounce/
-%attr(-,sympa,sympa) %{_localstatedir}/lib/sympa/list_data
-%dir %{_localstatedir}/lib/sympa/static_content/
-%dir %attr(-,sympa,sympa) %{_localstatedir}/lib/sympa/static_content/css/
-%dir %attr(-,sympa,sympa) %{_localstatedir}/lib/sympa/static_content/pictures/
-%{_localstatedir}/lib/sympa/static_content/external/
-%{_localstatedir}/lib/sympa/static_content/fonts/
-%{_localstatedir}/lib/sympa/static_content/icons/
-%{_localstatedir}/lib/sympa/static_content/js/
+%attr(-,sympa,sympa) %{_localstatedir}/lib/sympa/list_data/
+%attr(-,sympa,sympa) %{_localstatedir}/lib/sympa/css/
+%attr(-,sympa,sympa) %{_localstatedir}/lib/sympa/pictures/
 %attr(-,sympa,sympa) %{_localstatedir}/spool/sympa/
 %{_datadir}/sympa/
 %{_mandir}/man1/*
@@ -782,6 +782,7 @@ fi
 %changelog
 * Mon Mar 05 2018 Xavier Bachelot <xavier@bachelot.org> 6.2.25-0.2.b.2
 - Update to 6.2.25 beta 2.
+- Move static_content to an FHS compliant location.
 
 * Tue Feb 13 2018 Xavier Bachelot <xavier@bachelot.org> 6.2.25-0.1.b.1
 - Update to 6.2.25 beta 1.

--- a/SPECS/sympa-6.2.spec.in
+++ b/SPECS/sympa-6.2.spec.in
@@ -196,7 +196,7 @@ Requires:    fontawesome-fonts-web
 %if %{unbundle_raleway}
 Requires:    impallari-raleway-fonts
 %endif
-# FIXME: foundation icons 
+# FIXME: foundation icons
 #        See https://fedoraproject.org/wiki/Foundation_icons_font
 #            http://zurb.com/playground/uploads/upload/upload/288/foundation-icons.zip
 

--- a/SPECS/sympa-6.2.spec.in
+++ b/SPECS/sympa-6.2.spec.in
@@ -15,11 +15,11 @@
 %global unbundle_modernizr      0
 %global unbundle_respond        0%{?fedora}%{?rhel}
 
-%global pre_rel b.1
+%global pre_rel b.2
 
 Name:        sympa
 Version:     @VERSION@
-Release:     %{?pre_rel:0.}1%{?pre_rel:.%pre_rel}@REV@%{?dist}
+Release:     %{?pre_rel:0.}2%{?pre_rel:.%pre_rel}@REV@%{?dist}
 Summary:     Powerful multilingual List Manager
 Summary(fr): Gestionnaire de listes électroniques
 Summary(ja): 高機能で多言語対応のメーリングリスト管理ソフトウェア
@@ -723,7 +723,6 @@ fi
 %attr(4755,sympa,sympa) %{_libexecdir}/sympa/familyqueue
 %attr(4755,sympa,sympa) %{_libexecdir}/sympa/queue
 %attr(4750,root,sympa) %{_libexecdir}/sympa/sympa_newaliases-wrapper
-%attr(0750,sympa,sympa) %{_libexecdir}/sympa/sympa_smtpc
 %{_libexecdir}/sympa/sympa_soap_server.fcgi
 %attr(6755,sympa,sympa) %{_libexecdir}/sympa/sympa_soap_server-wrapper.fcgi
 %{_libexecdir}/sympa/wwsympa.fcgi
@@ -781,6 +780,9 @@ fi
 
 
 %changelog
+* Mon Mar 05 2018 Xavier Bachelot <xavier@bachelot.org> 6.2.25-0.2.b.2
+- Update to 6.2.25 beta 2.
+
 * Tue Feb 13 2018 Xavier Bachelot <xavier@bachelot.org> 6.2.25-0.1.b.1
 - Update to 6.2.25 beta 1.
 - Remove useless and bogus directories creation for conf override.

--- a/SPECS/sympa-6.2.spec.in
+++ b/SPECS/sympa-6.2.spec.in
@@ -17,11 +17,11 @@
 %global unbundle_modernizr      0
 %global unbundle_respond        0%{?fedora}%{?rhel}
 
-%global pre_rel b.2
+%global pre_rel b.3
 
 Name:        sympa
 Version:     @VERSION@
-Release:     %{?pre_rel:0.}2%{?pre_rel:.%pre_rel}@REV@%{?dist}
+Release:     %{?pre_rel:0.}3%{?pre_rel:.%pre_rel}@REV@%{?dist}
 Summary:     Powerful multilingual List Manager
 Summary(fr): Gestionnaire de listes électroniques
 Summary(ja): 高機能で多言語対応のメーリングリスト管理ソフトウェア
@@ -798,6 +798,9 @@ fi
 
 
 %changelog
+* Tue Mar 13 2018 Xavier Bachelot <xavier@bachelot.org> 6.2.25-0.3.b.3
+- Update to 6.2.25 beta 3.
+
 * Mon Mar 05 2018 Xavier Bachelot <xavier@bachelot.org> 6.2.25-0.2.b.2
 - Update to 6.2.25 beta 2.
 - Move static_content to an FHS compliant location.

--- a/SPECS/sympa-6.2.spec.in
+++ b/SPECS/sympa-6.2.spec.in
@@ -170,6 +170,7 @@ Requires:    perl(FCGI)
 Requires:    perl(AuthCAS)
 Requires:    perl(Clone)
 Requires:    perl(Crypt::CipherSaber)
+Requires:    perl(Crypt::Eksblowfish)
 Requires:    perl(Crypt::OpenSSL::X509)
 Requires:    perl(Crypt::SMIME)
 Requires:    perl(Data::Password)
@@ -800,6 +801,7 @@ fi
 %changelog
 * Tue Mar 13 2018 Xavier Bachelot <xavier@bachelot.org> 6.2.25-0.3.b.3
 - Update to 6.2.25 beta 3.
+- Add Requires on optional Crypt::Eksblowfish.
 
 * Mon Mar 05 2018 Xavier Bachelot <xavier@bachelot.org> 6.2.25-0.2.b.2
 - Update to 6.2.25 beta 2.


### PR DESCRIPTION
Hi Soji,

Here's the PR for sympa 6.2.25 beta 2 together with the static_content dir move:
- Update to 6.2.25 beta 2.
- Move static_content to an FHS compliant location.

It obviously needs to be merged after #24.

Regards,
Xavier