### PR TITLE
Fix owner/group for various conf files

### DIFF
--- a/sympa.spec
+++ b/sympa.spec
@@ -712,26 +712,26 @@ fi
 %dir %attr(-,sympa,sympa) %{_sysconfdir}/sympa/
 %{_sysconfdir}/sympa/README
 %config(noreplace) %attr(0640,sympa,sympa) %{_sysconfdir}/sympa/sympa.conf
-%config(noreplace,missingok) %attr(-,sympa,sympa) %{_sysconfdir}/sympa/auth.conf
-%config(noreplace,missingok) %attr(-,sympa,sympa) %{_sysconfdir}/sympa/charset.conf
-%config(noreplace,missingok) %attr(-,sympa,sympa) %{_sysconfdir}/sympa/crawlers_detection.conf
-%config(noreplace,missingok) %attr(-,sympa,sympa) %{_sysconfdir}/sympa/create_list.conf
-%config(noreplace,missingok) %attr(-,sympa,sympa) %{_sysconfdir}/sympa/edit_list.conf
-%config(noreplace,missingok) %attr(-,sympa,sympa) %{_sysconfdir}/sympa/nrcpt_by_domain.conf
-%config(noreplace,missingok) %attr(-,sympa,sympa) %{_sysconfdir}/sympa/topics.conf
-%config(noreplace,missingok) %attr(-,sympa,sympa) %{_sysconfdir}/sympa/mime.types
-%config(noreplace,missingok) %attr(-,sympa,sympa) %{_sysconfdir}/sympa/sympa.wsdl
-%dir %attr(-,sympa,sympa) %{_sysconfdir}/sympa/create_list_templates
-%dir %attr(-,sympa,sympa) %{_sysconfdir}/sympa/global_task_models
-%dir %attr(-,sympa,sympa) %{_sysconfdir}/sympa/list_task_models
-%dir %attr(-,sympa,sympa) %{_sysconfdir}/sympa/scenari
-%dir %attr(-,sympa,sympa) %{_sysconfdir}/sympa/mail_tt2
-%dir %attr(-,sympa,sympa) %{_sysconfdir}/sympa/web_tt2
-%dir %attr(-,sympa,sympa) %{_sysconfdir}/sympa/custom_actions
-%dir %attr(-,sympa,sympa) %{_sysconfdir}/sympa/custom_conditions
-%dir %attr(-,sympa,sympa) %{_sysconfdir}/sympa/data_sources
-%dir %attr(-,sympa,sympa) %{_sysconfdir}/sympa/families
-%dir %attr(-,sympa,sympa) %{_sysconfdir}/sympa/search_filters
+%config(noreplace,missingok) %{_sysconfdir}/sympa/auth.conf
+%config(noreplace,missingok) %{_sysconfdir}/sympa/charset.conf
+%config(noreplace,missingok) %{_sysconfdir}/sympa/crawlers_detection.conf
+%config(noreplace,missingok) %{_sysconfdir}/sympa/create_list.conf
+%config(noreplace,missingok) %{_sysconfdir}/sympa/edit_list.conf
+%config(noreplace,missingok) %{_sysconfdir}/sympa/nrcpt_by_domain.conf
+%config(noreplace,missingok) %{_sysconfdir}/sympa/topics.conf
+%config(noreplace,missingok) %{_sysconfdir}/sympa/mime.types
+%config(noreplace,missingok) %{_sysconfdir}/sympa/sympa.wsdl
+%dir %{_sysconfdir}/sympa/create_list_templates
+%dir %{_sysconfdir}/sympa/global_task_models
+%dir %{_sysconfdir}/sympa/list_task_models
+%dir %{_sysconfdir}/sympa/scenari
+%dir %{_sysconfdir}/sympa/mail_tt2
+%dir %{_sysconfdir}/sympa/web_tt2
+%dir %{_sysconfdir}/sympa/custom_actions
+%dir %{_sysconfdir}/sympa/custom_conditions
+%dir %{_sysconfdir}/sympa/data_sources
+%dir %{_sysconfdir}/sympa/families
+%dir %{_sysconfdir}/sympa/search_filters
 %config(missingok) %attr(-,sympa,sympa) %{_sysconfdir}/sympa/data_structure.current_version
 %config(noreplace) %{_sysconfdir}/sympa/aliases.sympa.sendmail
 %config(noreplace) %{_sysconfdir}/sympa/aliases.sympa.sendmail.db

--- a/sympa.spec
+++ b/sympa.spec
@@ -17,11 +17,11 @@
 %global unbundle_modernizr      0
 %global unbundle_respond        0%{?fedora}%{?rhel}
 
-%global pre_rel b.3
+#global pre_rel b.3
 
 Name:        sympa
-Version:     6.2.25
-Release:     %{?pre_rel:0.}3%{?pre_rel:.%pre_rel}%{?dist}
+Version:     6.2.26
+Release:     %{?pre_rel:0.}1%{?pre_rel:.%pre_rel}%{?dist}
 Summary:     Powerful multilingual List Manager
 Summary(fr): Gestionnaire de listes électroniques
 Summary(ja): 高機能で多言語対応のメーリングリスト管理ソフトウェア
@@ -797,6 +797,9 @@ fi
 
 
 %changelog
+* Tue Mar 20 2018 Xavier Bachelot <xavier@bachelot.org> 6.2.26-1
+- Update to 6.2.26.
+
 * Tue Mar 13 2018 Xavier Bachelot <xavier@bachelot.org> 6.2.25-0.3.b.3
 - Update to 6.2.25 beta 3.
 - Add Requires on optional Crypt::Eksblowfish.

--- a/sympa.spec
+++ b/sympa.spec
@@ -547,7 +547,8 @@ if [ $1 -gt 1 ]; then
             && rm -rf %{_localstatedir}/lib/%{name}/static_content/pictures/
     fi
     if [ ! -d %{_localstatedir}/lib/%{name}/static_content/css \
-        -a ! -d %{_localstatedir}/lib/%{name}/static_content/pictures ]; then
+        -a ! -d %{_localstatedir}/lib/%{name}/static_content/pictures \
+        -a -d %{_localstatedir}/lib/%{name}/static_content ]; then
         rm -r %{_localstatedir}/lib/%{name}/static_content/
     fi
 fi
@@ -799,6 +800,7 @@ fi
 %changelog
 * Tue Mar 20 2018 Xavier Bachelot <xavier@bachelot.org> 6.2.26-1
 - Update to 6.2.26.
+- Fix scriptlet.
 
 * Tue Mar 13 2018 Xavier Bachelot <xavier@bachelot.org> 6.2.25-0.3.b.3
 - Update to 6.2.25 beta 3.

--- a/sympa.spec
+++ b/sympa.spec
@@ -20,7 +20,7 @@
 #global pre_rel b.3
 
 Name:        sympa
-Version:     6.2.26
+Version:     6.2.28
 Release:     %{?pre_rel:0.}1%{?pre_rel:.%pre_rel}%{?dist}
 Summary:     Powerful multilingual List Manager
 Summary(fr): Gestionnaire de listes électroniques
@@ -798,6 +798,9 @@ fi
 
 
 %changelog
+* Thu Mar 22 2018 Xavier Bachelot <xavier@bachelot.org> 6.2.28-1
+- Update to 6.2.28.
+
 * Tue Mar 20 2018 Xavier Bachelot <xavier@bachelot.org> 6.2.26-1
 - Update to 6.2.26.
 - Fix scriptlet.


### PR DESCRIPTION
Only sympa.conf needs to be modified by sympa user, either with upgrade scripts
or when edited through the web interface (if enabled).
All other configuration files and directories can be owned by root.

This pull request needs to be merged after #27.