### PR TITLE
httpd 2.4+ with separate FastCGI service

### DIFF
--- a/sympa-httpd24-spawn_fcgi.conf
+++ b/sympa-httpd24-spawn_fcgi.conf
@@ -1,29 +1,28 @@
 ### Apache httpd 2.4 configuration for Sympa
+##
+## Note: As of 6.2.34-2, mod_proxy_fcgi was adopted instead of mod_fcgid.
+## * You have to edit /etc/sysconfig/sympa as described in it.
+## * Then, you have to run separate fastCGI services wwsympa and/or sympasoap:
+##   systemctl start wwsympa
+##   systemctl start sympasoap
 
 ## Definition of Sympa FastCGI server.
-<IfModule mod_fcgid.c>
-    # You may want to tune the Fcgid settings either here
-    # or in /etc/httpd/conf.d/fcgid.conf
-    #FcgidIOTimeout 300
-    #FcgidMaxRequestLen 131072
-
+<IfModule mod_proxy_fcgi.c>
     # If you changed wwsympa_url in sympa.conf, change this path too.
     <Location /sympa>
-        SetHandler fcgid-script
+        SetHandler "proxy:unix:/var/run/sympa/wwsympa.socket|fcgi://"
         # Don't forget to edit lines below!
         Require local
         #Require all granted
     </Location>
-    ScriptAlias /sympa /usr/libexec/sympa/wwsympa-wrapper.fcgi
 
 #    # You may uncomment following lines to enable SympaSOAP feature.
 #    <Location /sympasoap>
-#        SetHandler fcgid-script
+#        SetHandler "proxy:unix:/var/run/sympa/sympasoap.socket|fcgi://"
 #        # Don't forget to edit lines below!
 #        Require local
 #        #Require all granted
 #    </Location>
-#    ScriptAlias /sympasoap /usr/libexec/sympa/sympa_soap_server-wrapper.fcgi
 </IfModule>
 
 ## Other static contents

--- a/sympa-httpd24-spawn_fcgi.conf
+++ b/sympa-httpd24-spawn_fcgi.conf
@@ -1,6 +1,6 @@
 ### Apache httpd 2.4 configuration for Sympa
 ##
-## Note: As of 6.2.34-2, mod_proxy_fcgi was adopted instead of mod_fcgid.
+## Note: As of 6.2.35-0.1.b.1, mod_proxy_fcgi was adopted instead of mod_fcgid.
 ## * You have to edit /etc/sysconfig/sympa as described in it.
 ## * Then, you have to run separate fastCGI services wwsympa and/or sympasoap:
 ##   systemctl start wwsympa

--- a/sympa.spec
+++ b/sympa.spec
@@ -29,7 +29,7 @@ URL:         http://www.sympa.org
 Source0:     https://github.com/sympa-community/sympa/releases/download/%{version}%{?pre_rel}/%{name}-%{version}%{?pre_rel}.tar.gz
 
 Source100:   sympa-httpd22-fcgid.conf
-Source101:   sympa-httpd24-fcgid.conf
+Source101:   sympa-httpd24-spawn_fcgi.conf
 Source102:   sympa-lighttpd.conf
 Source103:   sympa-nginx-spawn_fcgi.conf
 Source104:   sympa-wwsympa.init
@@ -260,7 +260,11 @@ Summary(fr): Sympa avec Serveur HTTP Apache
 Summary(ja): SympaのApache HTTP Server対応
 Requires: %{name} = %{version}-%{release}
 Requires: httpd
+%if 0%{?fedora} || 0%{?rhel} >= 7
+Requires: spawn-fcgi
+%else
 Requires: mod_fcgid
+%endif
 Conflicts: %{name}-lighttpd, %{name}-nginx
 
 
@@ -779,6 +783,15 @@ fi
 
 %files httpd
 %config(noreplace) %{_sysconfdir}/httpd/conf.d/sympa.conf
+%if 0%{?fedora} || 0%{?rhel} >= 7
+%if %{use_systemd}
+%{_unitdir}/wwsympa.service
+%{_unitdir}/sympasoap.service
+%else
+%{_initrddir}/wwsympa
+%{_initrddir}/sympasoap
+%endif
+%endif
 
 
 %files lighttpd

--- a/sympa.spec
+++ b/sympa.spec
@@ -16,10 +16,10 @@
 %global unbundle_jqplot         0
 %global unbundle_respond        0%{?fedora}%{?rhel}
 
-#global pre_rel b.2
+global pre_rel b.1
 
 Name:        sympa
-Version:     6.2.34
+Version:     6.2.35
 Release:     %{?pre_rel:0.}1%{?pre_rel:.%pre_rel}%{?dist}
 Summary:     Powerful multilingual List Manager
 Summary(fr): Gestionnaire de listes électroniques
@@ -810,6 +810,10 @@ fi
 
 
 %changelog
+* Sun Aug 26 2018 IKEDA Soji <ikeda@cinversion.co.jp> 6.2.35-0.1.b.1
+- Update to 6.2.35b.1.
+- For sympa-httpd with Fedora & EL7: Use mod_proxy_fcgi instead of mod_fcgid.
+
 * Thu Jul 05 2018 Xavier Bachelot <xavier@bachelot.org> 6.2.34-1
 - Update to 6.2.34.
 


### PR DESCRIPTION
This PR depends on PR #36.

For sympa-httpd with Fedora & EL7: Use mod_proxy_fcgi instead of mod_fcgid.
