### PR TITLE
Changes to sympa.spec for RHEL 7

### DIFF
--- a/sympa.spec
+++ b/sympa.spec
@@ -8,7 +8,7 @@
 
 # Fonts
 #
-%global unbundle_fontawesome       1
+%global unbundle_fontawesome       0%{?fedora}
 # Not available for EL
 %global unbundle_raleway           0%{?fedora}
 # Not available
@@ -251,7 +251,11 @@ Provides:    bundled(js-jquery) = 3.2.1
 %endif
 # jquery-migrate
 %if %{unbundle_jquery_migrate}
+%if %{?el7}
+Requires:    python-XStatic-JQuery-Migrate
+%else 
 Requires:    xstatic-jquery-migrate-common
+%endif
 %else
 Provides:    bundled(js-jquery-migrate) = 1.4.1
 %endif
@@ -263,7 +267,11 @@ Provides:    bundled(js-jquery-minicolors) = 2.3.1
 %endif
 # jquery-ui
 %if %{unbundle_jquery_ui}
+%if %{?el7}
+Requires:    python-XStatic-jquery-ui
+%else
 Requires:    xstatic-jquery-ui-common
+%endif
 %else
 Provides:    bundled(js-jquery-ui) = 1.12.1
 %endif


### PR DESCRIPTION
Here are two changes we arrived at while building 6.2.38 for RHEL 7 using this RPM packaging. Thank you for maintaining this way to cleanly manage Sympa installations for RPM-based systems!

Use EPEL package names for JQuery UI and migrate packages under RHEL 7
----------------

These packages are available under RHEL 7 but with different names:

    xstatic-jquery-migrate-common -> python-XStatic-JQuery-Migrate
    xstatic-jquery-ui-common      -> python-XStatic-jquery-ui

Use bundled Font Awesome 4.3.0 fonts under RHEL
-----------------
The stock RHEL 7 fontawesome-fonts-web 4.1.0 lacks the "fa-user-times" icon used for the "delete owner" column header. 

The proposed change uses ``0%{?fedora}`` to only unbundle FontAwesome on Fedora systems, similarly to other conditionals in the SPEC file.