### PR TITLE
Missing directory for S/MIME user certificates

### DIFF
--- a/sympa.spec
+++ b/sympa.spec
@@ -641,6 +641,8 @@ for conffile in \
         %{buildroot}%{_sysconfdir}/%{name}/;
 done
 
+# Create directory for S/MIME user certificates
+mkdir -p %{buildroot}%{_localstatedir}/lib/sympa/X509-user-certs
 
 %check
 make check
@@ -901,6 +903,7 @@ fi
 %attr(-,sympa,sympa) %{_localstatedir}/lib/sympa/list_data/
 %attr(-,sympa,sympa) %{_localstatedir}/lib/sympa/css/
 %attr(-,sympa,sympa) %{_localstatedir}/lib/sympa/pictures/
+%attr(-,sympa,sympa) %{_localstatedir}/lib/sympa/X509-user-certs/
 %attr(-,sympa,sympa) %{_localstatedir}/spool/sympa/
 %{_datadir}/sympa/
 %{_mandir}/man1/*


### PR DESCRIPTION
When an S/MIME-signed message is sent, following warning is logged.

> sympa_msg[XXXXX]: err main::#243 > Sympa::Spindle::spin#83 > Sympa::Spindle::ProcessIncoming::_twist#204 > Sympa::Message::check_smime_signature#1344 Unable to create certificate file /var/lib/sympa/X509-user-certs/email@add.ress: No such file or directory

Fixed by creating missing directory.